### PR TITLE
readme: fix syntax error in example playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Copy the following playbook to a file like `install_proxmox.yml`:
               - clock.nyc.he.net
         - role: lae.proxmox
           vars:
-            - pve_group: all
-            - pve_reboot_on_kernel_update: true
+            pve_group: all
+            pve_reboot_on_kernel_update: true
 
 Install this role and a role for configuring NTP:
 


### PR DESCRIPTION
Fixes the following error:

```
ERROR! Vars in a RoleInclude must be specified as a dictionary. 

The error appears to be in '/runner/proxmox_nodes.yml': line 14, column 9, but may be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

      vars:
        - pve_group: all ^ here
```